### PR TITLE
userInfo tests

### DIFF
--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -10,11 +10,11 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   PDKTProgress:
-    :path: "../"
+    :path: ../
 
 SPEC CHECKSUMS:
   OCHamcrest: 6f03ffa81d12feab872638490a44ab0a6d3aca10
   OCMockito: 4981140c9a9ec06c31af40f636e3c0f25f27e6b2
   PDKTProgress: f6b8709e54bc4a02eebc9083283576c6e6ff1ee1
 
-COCOAPODS: 0.36.3
+COCOAPODS: 0.37.1

--- a/Demo/Tests/PDKTProgressTests.m
+++ b/Demo/Tests/PDKTProgressTests.m
@@ -26,7 +26,7 @@
 
 - (void)setUp {
     [super setUp];
-    self.progressHandler = [[PDKTProgress alloc] initWithUserInfo:nil];
+    self.progressHandler = [[PDKTProgress alloc] init];
     self.observer = mockProtocol(@protocol(PDKTProgressObserver));
 }
 
@@ -173,12 +173,6 @@
     
     MKTArgumentCaptor *argument = [MKTArgumentCaptor new];
     [[MKTVerifyCount(progressObserver, times(2)) withMatcher:[argument capture] forArgument:1] progressHandler:self.progressHandler didUpdateProgress:0];
-}
-
-- (void)testProgressStoresUserInfo {
-    NSDictionary *fakeUserInfo = mock([NSDictionary class]);
-    PDKTProgress *progressHandler = [[PDKTProgress alloc] initWithUserInfo:fakeUserInfo];
-    XCTAssertEqual(progressHandler.userInfo, fakeUserInfo);
 }
 
 - (void)testProgressStoresAnObjectForANewKeyInUserInfo {

--- a/Demo/Tests/PDKTProgressTests.m
+++ b/Demo/Tests/PDKTProgressTests.m
@@ -26,7 +26,7 @@
 
 - (void)setUp {
     [super setUp];
-    self.progressHandler = [[PDKTProgress alloc] init];
+    self.progressHandler = [[PDKTProgress alloc] initWithUserInfo:nil];
     self.observer = mockProtocol(@protocol(PDKTProgressObserver));
 }
 
@@ -173,6 +173,45 @@
     
     MKTArgumentCaptor *argument = [MKTArgumentCaptor new];
     [[MKTVerifyCount(progressObserver, times(2)) withMatcher:[argument capture] forArgument:1] progressHandler:self.progressHandler didUpdateProgress:0];
+}
+
+- (void)testProgressStoresUserInfo {
+    NSDictionary *fakeUserInfo = mock([NSDictionary class]);
+    PDKTProgress *progressHandler = [[PDKTProgress alloc] initWithUserInfo:fakeUserInfo];
+    XCTAssertEqual(progressHandler.userInfo, fakeUserInfo);
+}
+
+- (void)testProgressStoresAnObjectForANewKeyInUserInfo {
+    NSString *key = @"a key";
+    NSString *anObject = @"an object";
+    [self.progressHandler setUserInfoObject:anObject forKey:key];
+    XCTAssertEqual([self.progressHandler.userInfo valueForKey:key], anObject);
+}
+
+- (void)testProgressStoresANewObjectForAnExistingKeyInUserInfo {
+    NSString *key = @"a key";
+    NSString *anObject = @"an object";
+    [self.progressHandler setUserInfoObject:anObject forKey:key];
+    
+    NSString *newObject = @"a new object";
+    [self.progressHandler setUserInfoObject:newObject forKey:key];
+    XCTAssertEqual([self.progressHandler.userInfo valueForKey:key], newObject);
+}
+
+- (void)testProgressDeleteAnExistingObjectFromUserInfo {
+    NSString *key = @"a key";
+    NSString *anObject = @"an object";
+    [self.progressHandler setUserInfoObject:anObject forKey:key];
+    
+    [self.progressHandler setUserInfoObject:nil forKey:key];
+    XCTAssertEqual([self.progressHandler.userInfo valueForKey:key], nil);
+}
+
+- (void)testTryingToDeleteAnObjectThatDoesNotExistForAKeyFromUserInfo {
+    NSString *key = @"a key";
+    
+    [self.progressHandler setUserInfoObject:nil forKey:key];
+    XCTAssertEqual([self.progressHandler.userInfo valueForKey:key], nil);
 }
 
 @end

--- a/PDKTProgress.h
+++ b/PDKTProgress.h
@@ -10,32 +10,44 @@
 @class PDKTProgress;
 
 @protocol PDKTProgressObserver <NSObject>
+NS_ASSUME_NONNULL_BEGIN
 - (void)progressHandler:(PDKTProgress *)progressHandler didUpdateProgress:(CGFloat)progress;
+NS_ASSUME_NONNULL_END
 @end
 
 @interface PDKTProgress : NSObject
+NS_ASSUME_NONNULL_BEGIN
 @property (copy,nonatomic) NSString *identifier;
 @property (assign,nonatomic) CGFloat progress;
-@property (strong,nonatomic) NSTimer *fakeProgressTimer;
+@property (nullable, strong,nonatomic) NSTimer *fakeProgressTimer;
 @property (assign,nonatomic,readonly) CGFloat fakeProgressLimit;
 @property (assign,nonatomic,readonly) CGFloat fakeProgressIncrement;
+@property (copy, readonly) NSDictionary *userInfo;
+
+- (instancetype)initWithUserInfo:(nullable NSDictionary *)userInfoOrNil;
 - (void)reset;
 - (void)startFakeProgressUntil:(CGFloat)progressLimit withDuration:(NSTimeInterval)progressDuration;
 - (void)updateFakeProgress;
+- (void)setUserInfoObject:(nullable id)objectOrNil forKey:(nonnull NSString *)key;
+NS_ASSUME_NONNULL_END
 @end
 
 @interface PDKTProgress (Observer)<PDKTProgressObserver>
+NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic,readonly) NSArray *observers;
 
 - (void)addObserver:(id<PDKTProgressObserver>)observer;
 - (void)removeObserver:(id<PDKTProgressObserver>)observer;
+NS_ASSUME_NONNULL_END
 @end
 
 
 @interface PDKTProgress (Subprogress)
+NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic,readonly) NSArray *subprogresses;
 
 - (void)addSubprogress:(PDKTProgress *)subprogress;
 - (void)addSubprogress:(PDKTProgress *)subprogress withWeight:(CGFloat)weight;
 - (void)removeSubprogress:(PDKTProgress *)subprogress;
+NS_ASSUME_NONNULL_END
 @end

--- a/PDKTProgress.h
+++ b/PDKTProgress.h
@@ -24,7 +24,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (assign,nonatomic,readonly) CGFloat fakeProgressIncrement;
 @property (copy, readonly) NSDictionary *userInfo;
 
-- (instancetype)initWithUserInfo:(nullable NSDictionary *)userInfoOrNil;
 - (void)reset;
 - (void)startFakeProgressUntil:(CGFloat)progressLimit withDuration:(NSTimeInterval)progressDuration;
 - (void)updateFakeProgress;

--- a/PDKTProgress.m
+++ b/PDKTProgress.m
@@ -32,19 +32,15 @@ static NSString * const subprogressWeightKey = @"subprogressWeight";
 @synthesize progress = _progress;
 @synthesize fakeProgressTimer = _fakeProgressTimer;
 
-- (instancetype)initWithUserInfo:(NSDictionary *)userInfoOrNil {
+- (instancetype)init {
     self = [super init];
     if (self) {
         _observersTable = [NSHashTable weakObjectsHashTable];
         _subprogressesWeights = [NSMutableArray array];
-        _userInfo = userInfoOrNil;
     }
     return self;
 }
 
-- (instancetype)init {
-    return [self initWithUserInfo:nil];
-}
 - (void)reset{
     [self performInManThread:^{
         for (PDKTProgress *subprogress in self.subprogresses) {

--- a/PDKTProgress.m
+++ b/PDKTProgress.m
@@ -17,6 +17,7 @@ static NSString * const subprogressWeightKey = @"subprogressWeight";
 @property (assign,nonatomic,readwrite) CGFloat fakeProgressIncrement;
 @property (strong,nonatomic) NSHashTable *observersTable;
 @property (strong,nonatomic) NSMutableArray *subprogressesWeights;
+@property (copy, readwrite) NSDictionary *userInfo;
 @end
 
 @interface PDKTProgress (_Observer)
@@ -31,14 +32,18 @@ static NSString * const subprogressWeightKey = @"subprogressWeight";
 @synthesize progress = _progress;
 @synthesize fakeProgressTimer = _fakeProgressTimer;
 
-- (instancetype)init
-{
+- (instancetype)initWithUserInfo:(NSDictionary *)userInfoOrNil {
     self = [super init];
     if (self) {
         _observersTable = [NSHashTable weakObjectsHashTable];
         _subprogressesWeights = [NSMutableArray array];
+        _userInfo = userInfoOrNil;
     }
     return self;
+}
+
+- (instancetype)init {
+    return [self initWithUserInfo:nil];
 }
 - (void)reset{
     [self performInManThread:^{
@@ -111,6 +116,17 @@ static NSString * const subprogressWeightKey = @"subprogressWeight";
     }
     _fakeProgressTimer = fakeProgressTimer;
 }
+
+- (void)setUserInfoObject:(nullable id)objectOrNil forKey:(nonnull NSString *)key {
+    NSMutableDictionary *mutableUserInfo = [NSMutableDictionary dictionaryWithDictionary:self.userInfo];
+    if (!objectOrNil) {
+        [mutableUserInfo removeObjectForKey:key];
+    } else {
+        [mutableUserInfo setObject:objectOrNil forKey:key];
+    }
+    self.userInfo = [NSDictionary dictionaryWithDictionary:mutableUserInfo];
+}
+
 - (NSString *)description{
     NSMutableString *description = [NSMutableString stringWithFormat:@"<%@> (%f)",NSStringFromClass([self class]),self.progress];
     if (self.subprogresses.count) {

--- a/PDKTProgress.podspec
+++ b/PDKTProgress.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "PDKTProgress"
-  s.version          = "0.1.2"
+  s.version          = "0.1.1"
   s.summary          = "Handle progress and subprogress"
   s.description      = <<-DESC
                        This small class handles progress and uses the Decorator Pattern to handle

--- a/PDKTProgress.podspec
+++ b/PDKTProgress.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "PDKTProgress"
-  s.version          = "0.1.1"
+  s.version          = "0.1.2"
   s.summary          = "Handle progress and subprogress"
   s.description      = <<-DESC
                        This small class handles progress and uses the Decorator Pattern to handle


### PR DESCRIPTION
This PR adds the possibility to include an arbitrary userInfo dictionary to attached custom information to the progress.

This was done using the same API that Cocoa uses for NSProgress and other objects that uses userInfo pattern.

Moreover, I use the `nullable` modifier to indicate to the swift compiler that a property or variable could be nil. Therefore swift compiler can know if that property must be an optional. Making the import of this library into Swift projects easier.
This can be read at http://nshipster.com/swift-1.2/
